### PR TITLE
Change authentication storage from localStorage to Cookie

### DIFF
--- a/cypress/support/commands/api-commands.js
+++ b/cypress/support/commands/api-commands.js
@@ -35,9 +35,10 @@ Cypress.Commands.add('authenticate', () => {
 Cypress.Commands.add('loginViaApi', () => {
     return cy.authenticate().then((result) => {
         return cy.window().then((win) => {
-            win.localStorage.setItem('bearerAuth', JSON.stringify(result));
+            cy.setCookie('bearerAuth', JSON.stringify(result));
+
             // Return bearer token
-            return win.localStorage.getItem('bearerAuth');
+            return cy.getCookie('bearerAuth');
         });
     });
 });


### PR DESCRIPTION
The implementation in Shopware 6 will be changed in NEXT-7554. The E2E testsuite have to adapt this new way of saving the Bearer Token.