### PR TITLE
Improve subfolder handling in api requests

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -19,6 +19,7 @@
   },
   "env": {
     "apiVersion": "v1",
+    "apiPath": "**/api/v*",
     "user": "admin",
     "pass": "shopware",
     "salesChannelName": "Storefront",

--- a/cypress/support/commands/commands.js
+++ b/cypress/support/commands/commands.js
@@ -133,7 +133,7 @@ Cypress.Commands.add('typeMultiSelectAndCheck', {
     // Request we want to wait for later
     cy.server();
     cy.route({
-        url: '/api/**/search/*',
+        url: `${Cypress.env('apiPath')}/search/*`,
         method: 'post'
     }).as('filteredResultCall');
 
@@ -321,7 +321,7 @@ Cypress.Commands.add('typeAndCheckSearchField', {
     // Request we want to wait for later
     cy.server();
     cy.route({
-        url: '/api/**/search/**',
+        url: `${Cypress.env('apiPath')}/search/**`,
         method: 'post'
     }).as('searchResultCall');
 

--- a/cypress/support/commands/fixture-commands.js
+++ b/cypress/support/commands/fixture-commands.js
@@ -309,7 +309,7 @@ Cypress.Commands.add('setToInitialState', () => {
     return cy.log('Cleaning, please wait a little bit.').then(() => {
         return cy.cleanUpPreviousState();
     }).then(() => {
-        return cy.clearCacheAdminApi('DELETE', `api/${Cypress.env('apiVersion')}/_action/cache`);
+        return cy.clearCacheAdminApi('DELETE', `${Cypress.env('apiPath')}/_action/cache`);
     }).then(() => {
         return cy.setLocaleToEnGb();
     });

--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -51,7 +51,7 @@ Cypress.Commands.add('cleanUpPreviousState', () => {
 Cypress.Commands.add('openInitialPage', (url) => {
     // Request we want to wait for later
     cy.server();
-    cy.route('/api/**/_info/me').as('meCall');
+    cy.route(`${Cypress.env('apiPath')}/_info/me`).as('meCall');
 
 
     cy.visit(url);


### PR DESCRIPTION
In current state, there can be problems with using `cy.route` with subfolder as these are cut away in this case. This PR provides a wortkaround. Lets test this fix in a beta release though.