### PR TITLE
NEXT-11531 - Add commands `skipOnFeature` and `onlyOnFeature`

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ cy.get('.sw-cms-sidebar__block-preview')
   .dragTo('.sw-cms-section__empty-stage');
 ```
 
+### Skip test if a feature is not activated
+
+```js
+cy.onlyOnFeature('FEATURE_NEXT_101')
+```
+
+### Skip test if a feature is activated
+
+```js
+cy.skipOnFeature('FEATURE_NEXT_101')
+```
+
 ### Storefront commands
 
 #### Get the sales channel Id via Admin API

--- a/cypress/support/commands/commands.js
+++ b/cypress/support/commands/commands.js
@@ -507,3 +507,58 @@ Cypress.Commands.add('dragTo', { prevSubject: 'element' }, (subject, targetEl) =
         .should('have.class', 'is--valid-drop')
         .trigger('mouseup');
 });
+
+/**
+ * @name featureIsActive
+ * @function
+ * @param {window} win - Browser window object
+ * @param {string} feature - The feature name
+ * @return {boolean}
+ */
+function featureIsActive(win, feature) {
+    if (win !== undefined && win.Shopware !== undefined && win.Shopware.Feature !== undefined) {
+        return win.Shopware.Feature.isActive(feature);
+    }
+
+    return false;
+}
+
+/**
+ * Sorts a listing via clicking on name column
+ * @memberOf Cypress.Chainable#
+ * @name skipOnFeature
+ * @function
+ * @param {String} feature - Skip the test if feature is active
+ * @param {() => void} cb - Optional, run the given callback if the condition passes
+ */
+Cypress.Commands.add('skipOnFeature', (feature, cb) => {
+    cy.window().then((win) => {
+        const featureIsActive = featureIsActive(win, feature);
+
+        if (featureIsActive) {
+            cy.log(`Skipping test because feature flag '${feature}' is activated.`);
+        }
+
+        cy.skipOn(featureIsActive, cb);
+    });
+});
+
+/**
+ * Sorts a listing via clicking on name column
+ * @memberOf Cypress.Chainable#
+ * @name onlyOnFeature
+ * @function
+ * @param {String} feature - Skip test if feature is inactive
+ * @param {() => void} cb - Optional, run the given callback if the condition passes
+ */
+Cypress.Commands.add('onlyOnFeature', (feature, cb) => {
+    cy.window().then((win) => {
+        const featureIsActive = featureIsActive(win, feature);
+
+        if (featureIsActive) {
+            cy.log(`Running test because feature flag '${feature}' is activated.`);
+        }
+
+        cy.onlyOn(featureIsActive(win, feature), cb);
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1034,6 +1034,11 @@
         }
       }
     },
+    "@cypress/skip-test": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.5.0.tgz",
+      "integrity": "sha512-OqyToxRLUG/EAfZa0w8sAooOW6tr8pYCBpo3SLsKycrV2RTj9Sy7rB+5U0MvES87kWCHtO10qMIESuw8RiEYyQ=="
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "cypress-select-tests": "^1.4.1",
     "lodash": "4.17.19",
     "lodash.sample": "4.2.1",
-    "uuid": "3.3.3"
+    "uuid": "3.3.3",
+    "@cypress/skip-test": "^2.5.0"
   },
   "peerDependencies": {
     "cypress": "^4.0.0"


### PR DESCRIPTION
To make feature development including E2E tests a bit smoother, I want to add two helper commands, that skip or only run a test depending on a feature flag.