### PR TITLE
fix user & pass env properties selection

### DIFF
--- a/cypress/support/commands/api-commands.js
+++ b/cypress/support/commands/api-commands.js
@@ -14,8 +14,8 @@ Cypress.Commands.add('authenticate', () => {
             grant_type: Cypress.env('grant') ? Cypress.env('grant') : 'password',
             client_id: Cypress.env('client_id') ? Cypress.env('client_id') : 'administration',
             scopes: Cypress.env('scope') ? Cypress.env('scope') : 'write',
-            username: Cypress.env('username') ? Cypress.env('user') : 'admin',
-            password: Cypress.env('password') ? Cypress.env('pass') : 'shopware'
+            username: Cypress.env('username') || Cypress.env('user') || 'admin',
+            password: Cypress.env('password') || Cypress.env('pass') || 'shopware'
         }
     ).then((responseData) => {
         return {


### PR DESCRIPTION
Currently, setting a custom env username and password in the ``cypress.json`` is somewhat broken.

The ``authenticate`` command is searching for a ``username`` property just so that it can select a ``user`` property.

Therefor, setting a ``username`` property will always revert to the default right-hand side value ``admin``,
when a ``user`` property is not present.

Likewise, setting a ``user`` property will also always revert to the default right-hand side value ``admin``,
when a ``username`` property is not present.

The same applies to the ``password`` and ``pass`` properties.

To make the current implementation work, one has to define both properties in the ``cypress.json``:
 
```json
"env": {
        "username": "my-user",
        "password": "my-password",
        "user": "my-user",
        "pass": "my-password"
}
```

With the fix provided in this PR, one can use either properties (for backward-compatibility).

```json
"env": {
        "username": "my-user",
        "password": "my-password"
}
```

```json
"env": {
        "user": "my-user",
        "pass": "my-password"
}
```

This PR is targeted against the 1.x branch, but also applies to 2.x:  https://github.com/shopware/e2e-testsuite-platform/blob/306d4999e424a9c1216e2303494c7287a92d3f9c/cypress/support/commands/api-commands.js#L17



