### PR TITLE
Patch/locale selection

### DIFF
--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -68,7 +68,7 @@ Cypress.Commands.add('openInitialPage', (url) => {
  * @function
  */
 Cypress.Commands.add('setLocale', (locale = Cypress.env('locale')) => {
-    cy.window().then((win) => {
+    return cy.window().then((win) => {
         win.localStorage.setItem('sw-admin-locale', locale)
     });
 });
@@ -80,6 +80,6 @@ Cypress.Commands.add('setLocale', (locale = Cypress.env('locale')) => {
  * @function
  */
 Cypress.Commands.add('setLocaleToEnGb', () => {
-    cy.window().then((win) => cy.setLocale('en-GB'));
+    return cy.window().then((win) => cy.setLocale('en-GB'));
 });
 

--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -62,14 +62,16 @@ Cypress.Commands.add('openInitialPage', (url) => {
 });
 
 /**
- * Switches administration UI locale to locale in env
+ * Switches administration UI locale
  * @memberOf Cypress.Chainable#
  * @name setLocale
  * @function
  */
-Cypress.Commands.add('setLocale', () => cy.window().then((win) => {
-    win.localStorage.setItem('sw-admin-locale', Cypress.env('locale'));
-}));
+Cypress.Commands.add('setLocale', (locale = Cypress.env('locale')) =>
+    cy.window().then((win) => {
+        win.localStorage.setItem('sw-admin-locale', locale);
+    })
+);
 
 /**
  * Switches administration UI locale to EN_GB
@@ -78,5 +80,5 @@ Cypress.Commands.add('setLocale', () => cy.window().then((win) => {
  * @function
  */
 Cypress.Commands.add('setLocaleToEnGb', () => cy.window().then((win) => {
-    win.localStorage.setItem('sw-admin-locale', 'en-GB');
+    cy.setLocale('en-GB');
 }));

--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -67,11 +67,11 @@ Cypress.Commands.add('openInitialPage', (url) => {
  * @name setLocale
  * @function
  */
-Cypress.Commands.add('setLocale', (locale = Cypress.env('locale')) =>
+Cypress.Commands.add('setLocale', (locale = Cypress.env('locale')) => {
     cy.window().then((win) => {
-        win.localStorage.setItem('sw-admin-locale', locale);
-    })
-);
+        win.localStorage.setItem('sw-admin-locale', locale)
+    });
+});
 
 /**
  * Switches administration UI locale to EN_GB
@@ -79,6 +79,7 @@ Cypress.Commands.add('setLocale', (locale = Cypress.env('locale')) =>
  * @name setLocaleToEnGb
  * @function
  */
-Cypress.Commands.add('setLocaleToEnGb', () => cy.window().then((win) => {
-    cy.setLocale('en-GB');
-}));
+Cypress.Commands.add('setLocaleToEnGb', () => {
+    cy.window().then((win) => cy.setLocale('en-GB'));
+});
+

--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -62,13 +62,21 @@ Cypress.Commands.add('openInitialPage', (url) => {
 });
 
 /**
+ * Switches administration UI locale to locale in env
+ * @memberOf Cypress.Chainable#
+ * @name setLocale
+ * @function
+ */
+Cypress.Commands.add('setLocale', () => cy.window().then((win) => {
+    win.localStorage.setItem('sw-admin-locale', Cypress.env('locale'));
+}));
+
+/**
  * Switches administration UI locale to EN_GB
  * @memberOf Cypress.Chainable#
  * @name setLocaleToEnGb
  * @function
  */
-Cypress.Commands.add('setLocaleToEnGb', () => {
-    return cy.window().then((win) => {
-        win.localStorage.setItem('sw-admin-locale', Cypress.env('locale'));
-    });
-});
+Cypress.Commands.add('setLocaleToEnGb', () => cy.window().then((win) => {
+    win.localStorage.setItem('sw-admin-locale', 'en-GB');
+}));


### PR DESCRIPTION
Currently, the command ``setLocaleToEnGb`` is not doing what it's supposed to do, that is always setting the locale to en-GB.
It only does so, when the env property ``locale`` in the ``cypress.json`` is set to ``en-GB``:

```json
"env": {
        "locale": "en-GB",
}
```

If the ``locale`` property is set to ``de-DE``, the command ``setLocaleToEnGb`` will be using that isoCode despite it name telling us to use ``en-GB``.

Solution:

Rather than using ``Cypress.env('locale')`` in ``setLocaleToEnGb``, we can just hardcode the isoCode.

A new ``setLocale`` command can then be used to actually set the locale as defined in the env ``locale`` property,
or by calling it with the desired isoCode.

This allows for setting the locale interchangeably:

```js
    cy.setLocale();         // empty arg = uses Cypress.env('locale')

    cy.setLocale('de-DE');  // uses the locale from arg (ignores Cypress.env('locale'))
    
    cy.setLocaleToEnGb();   // uses en-GB (helper/backward-compatibility)
```
