### PR TITLE
Add support for multiple values in multi select inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,13 @@ cy.get('.select-payment-method')
   });
 ```
 
+#### Types multiple values in a sw-multi-select field and checks if the content was set correctly (multi select)
+
+```js
+cy.get('.select-payment-method')
+  .typeMultiSelectAndCheckMultiple(['Invoice', 'Paid in advance', 'Cash on delivery']);
+```
+
 #### Types in an sw-select field (single select)
 
 ```js

--- a/cypress/support/commands/commands.js
+++ b/cypress/support/commands/commands.js
@@ -204,6 +204,70 @@ Cypress.Commands.add(
 );
 
 /**
+ * Types in a sw-multi-select field all the specified values and checks if the content was correctly set.
+ * @memberOf Cypress.Chainable#
+ * @name typeMultiSelectAndCheckMultiple
+ * @function
+ * @param {String[]} values - Desired values of the element
+ */
+Cypress.Commands.add(
+    "typeMultiSelectAndCheckMultiple",
+    {
+        prevSubject: "element",
+    },
+    (subject, values) => {
+        // Request we want to wait for later
+        cy.server();
+        cy.route({
+            url: `${Cypress.env("apiPath")}/search/*`,
+            method: "post",
+        }).as("filteredResultCall");
+
+        cy.wrap(subject)
+            .scrollIntoView() // try to make it visible so it does not error out if it is not in view
+            .should("be.visible");
+
+        // type in each value and select it
+        for (let i = 0; i < values.length; i += 1) {
+            cy.get(`${subject.selector} .sw-select-selection-list__input`)
+                .clear()
+                .type(values[i])
+                .should(
+                    "have.value",
+                    values[i]
+                );
+
+            // wait for the first request (which happens on opening / clicking in the input
+            cy.wait("@filteredResultCall").then(() => {
+                // wait for the second request (which happens on stop typing with the actual search)
+                cy.wait("@filteredResultCall").then(() => {
+                    cy.get(".sw-loader__element").should("not.exist");
+                });
+            });
+
+            // select the value
+            cy.contains('.sw-select-result-list__content .sw-select-result', values[i]).should('be.visible').click();
+        }
+
+        // close search results
+        cy.get(`${subject.selector} .sw-select-selection-list__input`).type("{esc}");
+        cy.get(`${subject.selector} .sw-select-result-list`).should(
+            "not.exist"
+        );
+
+        // check if all values are selected
+        for (let i = 0; i < values.length; i += 1) {
+            cy.get(`${subject.selector} .sw-select-selection-list`)
+                .should('contain', values[i]);
+        }
+
+        // return same element as the one this command works on so it can be chained with other commands.
+        // otherwise it will return the last element which is in this case a '.sw-select-selection-list' element.
+        cy.wrap(subject);
+    }
+);
+
+/**
  * Types in an sw-select field
  * @memberOf Cypress.Chainable#
  * @name typeSingleSelect


### PR DESCRIPTION
This MR adds another Command `typeMultiSelectAndCheckMultiple` which works on `sw-multi-select` input fields. It allows to specify multiple values which will be selected (see example in `README.md`).

This MR does not touch the existing `typeMultiSelectAndCheck` Command to stay compatible and keep a clean and simple interface with the new one.