### PR TITLE
set category API response limit to 1

### DIFF
--- a/cypress/support/service/administration/fixture/product.fixture.js
+++ b/cypress/support/service/administration/fixture/product.fixture.js
@@ -58,7 +58,8 @@ class ProductFixture extends AdminFixtureService {
                     field: 'name',
                     type: 'equals',
                     value: categoryName
-                }]
+                }],
+                limit: 1
             })
         }).then((result) => {
             return this.update({


### PR DESCRIPTION
This fixes a problem in the product-fixture-service when there are multiple categories with the same name.

If there are categories with the same name, the current implementation returns the result as an array of categories,
whereas the code on [line 74](https://github.com/shopware/e2e-testsuite-platform/blob/9fc80a09bdd3985568e7d4ea99c407974ad78407/cypress/support/service/administration/fixture/product.fixture.js#L74) expects an object. Thus the category id (`result.id`) can't be set and the api-call is dismissed.

https://github.com/shopware/e2e-testsuite-platform/blob/9fc80a09bdd3985568e7d4ea99c407974ad78407/cypress/support/service/administration/fixture/product.fixture.js#L74

This fix limits the response from the API to 1 and will therefor always respond with an object, keeping existing and future code intact.

<img src="https://i.imgur.com/xxu3lAf.png" />