### PR TITLE
NEXT-14935 - Add admin order fixtures

### DIFF
--- a/cypress/support/commands/fixture-commands.js
+++ b/cypress/support/commands/fixture-commands.js
@@ -6,6 +6,7 @@ const PaymentMethodFixture = require('../service/administration/fixture/payment-
 const NewsletterRecipientFixture = require('../service/administration/fixture/newsletter-recipient.fixture');
 const CmsFixture = require('../service/administration/fixture/cms.fixture');
 const OrderFixture = require('../service/saleschannel/fixture/order.fixture');
+const OrderAdminFixture = require('../service/administration/fixture/order.fixture');
 const AdminSalesChannelFixture= require('../service/administration/fixture/sales-channel.fixture');
 const Fixture = require('../service/administration/fixture.service');
 
@@ -309,6 +310,23 @@ Cypress.Commands.add('createGuestOrder', (productId, userData) => {
         return Cypress._.merge(result, userData);
     }).then((data) => {
         return fixture.createGuestOrder(productId, data);
+    });
+});
+
+/**
+ * Create guest order fixture via admin api
+ * @memberOf Cypress.Chainable#
+ * @name createAdminOrder
+ * @function
+ * @param {Object} userData - Data proved for this order to be created
+ */
+Cypress.Commands.add('createAdminOrder', (userData) => {
+    const fixture = new OrderAdminFixture();
+
+    return cy.fixture('order').then((result) => {
+        return Cypress._.merge(result, userData);
+    }).then((data) => {
+        return fixture.setOrderFixture(data);
     });
 });
 

--- a/cypress/support/service/administration/fixture/order.fixture.js
+++ b/cypress/support/service/administration/fixture/order.fixture.js
@@ -1,0 +1,79 @@
+const AdminFixtureService = require('../fixture.service.js');
+const uuid = require('uuid/v4');
+
+class OrderFixture extends AdminFixtureService {
+    setOrderFixture(userData = {}) {
+        const customerData = {
+            firstName: 'Max',
+            lastName: 'Mustermann',
+            email: 'example@shopware.com',
+            street: 'Ebbinghoff 10',
+            zipcode: '48624',
+            city: 'Schöppingen'
+        };
+
+        const findSalutationId = () => this.search('salutation', {
+            field: 'displayName',
+            type: 'equals',
+            value: 'Mr.'
+        });
+        const findCountryId = () => this.search('country', {
+            field: 'iso',
+            type: 'equals',
+            value: 'DE'
+        });
+        const findCurrencyId = () => this.search('currency', {
+            field: 'name',
+            type: 'equals',
+            value: 'Euro'
+        });
+        const findStateId = () => this.search('state-machine-state', {
+            field: 'technicalName',
+            type: 'equals',
+            value: 'open'
+        });
+        const findSalesChannelId = () => this.search('sales-channel', {
+            field: 'name',
+            type: 'equals',
+            value: 'Headless'
+        });
+
+        return Promise.all([
+            findSalutationId(),
+            findCountryId(),
+            findCurrencyId(),
+            findStateId(),
+            findSalesChannelId()
+        ]).then(([salutation, country, currency, state, salesChannel]) => {
+            if (state && state.length > 1) {
+                state = state[0];
+            }
+
+            return Object.assign({}, {
+                currencyId: currency.id,
+                currencyFactor: currency.attributes.factor,
+                stateId: state.id,
+                salesChannelId: salesChannel.id,
+                billingAddress: {
+                    ...customerData,
+                    salutationId: salutation.id,
+                    countryId: country.id
+                },
+                orderCustomer: {
+                    ...customerData,
+                    salutationId: salutation.id,
+                    billingAddress: {
+                        ...customerData,
+                        salutationId: salutation.id,
+                        countryId: country.id
+                    }
+                }
+            }, userData);
+        }).then((finalOrderData) => {
+            return this.apiClient.post('/order?_response=true', finalOrderData);
+        });
+    }
+}
+
+module.exports = OrderFixture;
+global.OrderFixtureService = new OrderFixture();


### PR DESCRIPTION
Currently, the administration e2e tests use order fixtures using the store-api to add orders for their tests. Therefore, you can only add orders during the API cart process. But for that, the API user has no rights to add line items of types different from 'product' or nested line items.

For that, this PR adds the addition of `createAdminOrder` to provide a different way to create orders with all line item types.