### PR TITLE
chore(deps) - Updates import of uuid/v4 module

### DIFF
--- a/cypress/support/commands/storefront-api-commands.js
+++ b/cypress/support/commands/storefront-api-commands.js
@@ -1,5 +1,5 @@
 const sample = require('lodash.sample');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 
 /**
  * Sends a POST using the admin api to the server

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,6 +1,6 @@
 // Import general dependencies
 const _ = require('lodash');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 
 require('@cypress/skip-test/support');
 

--- a/cypress/support/service/administration/fixture.service.js
+++ b/cypress/support/service/administration/fixture.service.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 const AdminApiService = require('./admin-api.service');
 class AdminFixtureService {
     constructor() {

--- a/cypress/support/service/administration/fixture/order.fixture.js
+++ b/cypress/support/service/administration/fixture/order.fixture.js
@@ -1,5 +1,5 @@
 const AdminFixtureService = require('../fixture.service.js');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 
 class OrderFixture extends AdminFixtureService {
     setOrderFixture(userData = {}) {

--- a/cypress/support/service/saleschannel/fixture.service.js
+++ b/cypress/support/service/saleschannel/fixture.service.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const uuid = require('uuid/v4');
+const { v4: uuid } = require('uuid');
 const StoreApiService = require('./store-api.service');
 const AdminApiService = require('../administration/admin-api.service');
 const AdminFixtureService = require('../administration/fixture.service.js');


### PR DESCRIPTION
The import syntax was changed in a recent major update of `uuid`.

**Old syntax:**

```js
const uuid = require('uuid/v4');
```

**New syntax:**

```js
const { v4: uuid } = require('uuid');
```