### PR TITLE
NEXT-12388 - Reintroduce cypress skip tests

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -2,6 +2,9 @@
 const _ = require('lodash');
 const { v4: uuid } = require('uuid');
 
+// Load and register the skip feature
+require('@cypress/skip-test/support');
+
 // Load and register the grep feature
 require('cypress-grep')();
 


### PR DESCRIPTION
This was mistakenly deleted but needs to be reintroduced in order to get the pipeline running again