### PR TITLE
NEXT-16227 - Cache auth tokens in `AdminApiService`

### DIFF
--- a/cypress/support/commands/api-commands.js
+++ b/cypress/support/commands/api-commands.js
@@ -7,23 +7,35 @@ const Fixture = require('../service/administration/fixture.service');
  * @function
  */
 Cypress.Commands.add('authenticate', () => {
-    return cy.request(
-        'POST',
-        '/api/oauth/token',
-        {
-            grant_type: Cypress.env('grant') ? Cypress.env('grant') : 'password',
-            client_id: Cypress.env('client_id') ? Cypress.env('client_id') : 'administration',
-            scopes: Cypress.env('scope') ? Cypress.env('scope') : 'write',
-            username: Cypress.env('username') || Cypress.env('user') || 'admin',
-            password: Cypress.env('password') || Cypress.env('pass') || 'shopware'
+    return cy.getCookie('_apiAuth').then((cookie) => {
+        if (cookie) {
+            return cy.log('cached /api/oauth/token')
+                .then(() => JSON.parse(cookie.value));
         }
-    ).then((responseData) => {
-        return {
-            access: responseData.body.access_token,
-            refresh: responseData.body.refresh_token,
-            expiry: Math.round(+new Date() / 1000) + responseData.body.expires_in
-        };
-    });
+
+        return cy.request(
+            'POST',
+            '/api/oauth/token',
+            {
+                grant_type: Cypress.env('grant') ? Cypress.env('grant') : 'password',
+                client_id: Cypress.env('client_id') ? Cypress.env('client_id') : 'administration',
+                scopes: Cypress.env('scope') ? Cypress.env('scope') : 'write',
+                username: Cypress.env('username') || Cypress.env('user') || 'admin',
+                password: Cypress.env('password') || Cypress.env('pass') || 'shopware'
+            }
+        ).then((responseData) => {
+            let result = responseData.body;
+            result.access = result.access_token;
+            result.refresh = result.refresh_token;
+            result.expiry = Math.round(+new Date() / 1000) + responseData.body.expires_in;
+
+            cy.log('request /api/oauth/token')
+
+            // cookie should expire before the token is expired
+            return cy.setCookie('_apiAuth', JSON.stringify(result), { expiry: result.expiry - 10})
+                .then(() => result)
+        });
+    })
 });
 
 /**
@@ -34,12 +46,11 @@ Cypress.Commands.add('authenticate', () => {
  */
 Cypress.Commands.add('loginViaApi', () => {
     return cy.authenticate().then((result) => {
-        return cy.window().then((win) => {
-            cy.setCookie('bearerAuth', JSON.stringify(result));
+        // cookie should expire before the token is invalid
+        cy.setCookie('bearerAuth', JSON.stringify(result), { expiry: result.expiry - 5});
 
-            // Return bearer token
-            return cy.getCookie('bearerAuth');
-        });
+        // Return bearer token
+        return cy.getCookie('bearerAuth');
     });
 });
 
@@ -51,12 +62,14 @@ Cypress.Commands.add('loginViaApi', () => {
  * @param {Object} data - Necessary data for the API request
  */
 Cypress.Commands.add('searchViaAdminApi', (data) => {
-    const fixture = new Fixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new Fixture(authInformation);
 
-    return fixture.search(data.endpoint, {
-        field: data.data.field,
-        type: 'equals',
-        value: data.data.value
+        return fixture.search(data.endpoint, {
+            field: data.data.field,
+            type: 'equals',
+            value: data.data.value
+        });
     });
 });
 

--- a/cypress/support/commands/fixture-commands.js
+++ b/cypress/support/commands/fixture-commands.js
@@ -19,17 +19,19 @@ const Fixture = require('../service/administration/fixture.service');
  * @param {Object} [options={}] - Options concerning deletion
  */
 Cypress.Commands.add('createDefaultFixture', (endpoint, data = {}, jsonPath) => {
-    const fixture = new Fixture();
-    let finalRawData = {};
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new Fixture(authInformation);
+        let finalRawData = {};
 
-    if (!jsonPath) {
-        jsonPath = endpoint;
-    }
+        if (!jsonPath) {
+            jsonPath = endpoint;
+        }
 
-    return cy.fixture(jsonPath).then((json) => {
-        finalRawData = Cypress._.merge(json, data);
+        return cy.fixture(jsonPath).then((json) => {
+            finalRawData = Cypress._.merge(json, data);
 
-        return fixture.create(endpoint, finalRawData);
+            return fixture.create(endpoint, finalRawData);
+        });
     });
 });
 
@@ -42,12 +44,14 @@ Cypress.Commands.add('createDefaultFixture', (endpoint, data = {}, jsonPath) => 
  * @param {Object} [options={}] - Options concerning creation
  */
 Cypress.Commands.add('createProductFixture', (userData = {}) => {
-    const fixture = new ProductFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new ProductFixture(authInformation);
 
-    return cy.fixture('product').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setProductFixture(data);
+        return cy.fixture('product').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setProductFixture(data);
+        });
     });
 });
 
@@ -59,12 +63,14 @@ Cypress.Commands.add('createProductFixture', (userData = {}) => {
  * @param {object} [userData={}] - Additional category data
  */
 Cypress.Commands.add('createCategoryFixture', (userData = {}) => {
-    const fixture = new CategoryFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new CategoryFixture(authInformation);
 
-    return cy.fixture('category').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setCategoryFixture(data);
+        return cy.fixture('category').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setCategoryFixture(data);
+        });
     });
 });
 
@@ -77,12 +83,14 @@ Cypress.Commands.add('createCategoryFixture', (userData = {}) => {
  * @param {Object} [options={}] - Options concerning creation
  */
 Cypress.Commands.add('createSalesChannelFixture', (userData = {}) => {
-    const fixture = new AdminSalesChannelFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new AdminSalesChannelFixture(authInformation);
 
-    return cy.fixture('product').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setSalesChannelFixture(data);
+        return cy.fixture('product').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setSalesChannelFixture(data);
+        });
     });
 });
 
@@ -94,8 +102,10 @@ Cypress.Commands.add('createSalesChannelFixture', (userData = {}) => {
  * @param {String} [salesChannelName=Storefront] - Options concerning creation
  */
 Cypress.Commands.add('setSalesChannelDomain', (salesChannelName = 'Storefront') => {
-    const fixture = new AdminSalesChannelFixture();
-    return fixture.setSalesChannelDomain(salesChannelName)
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new AdminSalesChannelFixture(authInformation);
+        return fixture.setSalesChannelDomain(salesChannelName)
+    });
 });
 
 /**
@@ -106,14 +116,16 @@ Cypress.Commands.add('setSalesChannelDomain', (salesChannelName = 'Storefront') 
  * @param {Object} [userData={}] - Options concerning creation
  */
 Cypress.Commands.add('createCustomerFixture', (userData = {}) => {
-    const fixture = new CustomerFixture();
-    let customerJson = null;
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new CustomerFixture(authInformation);
+        let customerJson = null;
 
-    return cy.fixture('customer').then((result) => {
-        customerJson = Cypress._.merge(result, userData);
-        return cy.fixture('customer-address');
-    }).then((data) => {
-        return fixture.setCustomerFixture(customerJson, data);
+        return cy.fixture('customer').then((result) => {
+            customerJson = Cypress._.merge(result, userData);
+            return cy.fixture('customer-address');
+        }).then((data) => {
+            return fixture.setCustomerFixture(customerJson, data);
+        });
     });
 });
 
@@ -125,18 +137,20 @@ Cypress.Commands.add('createCustomerFixture', (userData = {}) => {
  * @param {Object} [userData={}] - Options concerning creation
  */
 Cypress.Commands.add('createCmsFixture', (userData = {}) => {
-    const fixture = new CmsFixture();
-    let pageJson = null;
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new CmsFixture(authInformation);
+        let pageJson = null;
 
-    return cy.fixture('cms-page').then((data) => {
-        pageJson = data;
-        return cy.fixture('cms-section')
-    }).then((data) => {
-        return Cypress._.merge(pageJson, {
-            sections: [data]
+        return cy.fixture('cms-page').then((data) => {
+            pageJson = data;
+            return cy.fixture('cms-section')
+        }).then((data) => {
+            return Cypress._.merge(pageJson, {
+                sections: [data]
+            });
+        }).then((data) => {
+            return fixture.setCmsPageFixture(data);
         });
-    }).then((data) => {
-        return fixture.setCmsPageFixture(data);
     });
 });
 
@@ -149,15 +163,17 @@ Cypress.Commands.add('createCmsFixture', (userData = {}) => {
  * @param {Object} [userData={}] - Options concerning creation
  */
 Cypress.Commands.add('createPropertyFixture', (options, userData) => {
-    let json = {};
-    const fixture = new Fixture();
+    return cy.authenticate().then((authInformation) => {
+        let json = {};
+        const fixture = new Fixture(authInformation);
 
-    return cy.fixture('property-group').then((result) => {
-        json = Cypress._.merge(result, options);
-    }).then(() => {
-        return Cypress._.merge(json, userData);
-    }).then((result) => {
-        return fixture.create('property-group', result);
+        return cy.fixture('property-group').then((result) => {
+            json = Cypress._.merge(result, options);
+        }).then(() => {
+            return Cypress._.merge(json, userData);
+        }).then((result) => {
+            return fixture.create('property-group', result);
+        });
     });
 });
 
@@ -168,25 +184,27 @@ Cypress.Commands.add('createPropertyFixture', (options, userData) => {
  * @function
  */
 Cypress.Commands.add('createLanguageFixture', () => {
-    let json = {};
-    const fixture = new Fixture();
+    return cy.authenticate().then((authInformation) => {
+        let json = {};
+        const fixture = new Fixture(authInformation);
 
-    return cy.fixture('language').then((result) => {
-        json = result;
+        return cy.fixture('language').then((result) => {
+            json = result;
 
-        return fixture.search('locale', {
-            field: 'code',
-            type: 'equals',
-            value: 'en-PH'
+            return fixture.search('locale', {
+                field: 'code',
+                type: 'equals',
+                value: 'en-PH'
+            });
+        }).then((result) => {
+            return {
+                name: json.name,
+                localeId: result.id,
+                parentId: json.parentId
+            };
+        }).then((result) => {
+            return fixture.create('language', result);
         });
-    }).then((result) => {
-        return {
-            name: json.name,
-            localeId: result.id,
-            parentId: json.parentId
-        };
-    }).then((result) => {
-        return fixture.create('language', result);
     });
 });
 
@@ -198,12 +216,14 @@ Cypress.Commands.add('createLanguageFixture', () => {
  * @param {Object} [options={}] - Options concerning creation
  */
 Cypress.Commands.add('createShippingFixture', (userData) => {
-    const fixture = new ShippingFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new ShippingFixture(authInformation);
 
-    return cy.fixture('shipping-method').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setShippingFixture(data);
+        return cy.fixture('shipping-method').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setShippingFixture(data);
+        });
     });
 });
 
@@ -215,12 +235,14 @@ Cypress.Commands.add('createShippingFixture', (userData) => {
  * @param {Object} [options={}] - Options concerning creation
  */
 Cypress.Commands.add('createPaymentMethodFixture', (userData) => {
-    const fixture = new PaymentMethodFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new PaymentMethodFixture(authInformation);
 
-    return cy.fixture('payment-method').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setPaymentMethodFixture(data);
+        return cy.fixture('payment-method').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setPaymentMethodFixture(data);
+        });
     });
 });
 
@@ -232,12 +254,14 @@ Cypress.Commands.add('createPaymentMethodFixture', (userData) => {
  * @param {Object} [options={}] - Options concerning creation
  */
 Cypress.Commands.add('createNewsletterRecipientFixture', (recipient) => {
-    const fixture = new NewsletterRecipientFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new NewsletterRecipientFixture(authInformation);
 
-    return cy.fixture('customer').then((result) => {
-        return Cypress._.merge(result, recipient);
-    }).then((recipientData) => {
-        return fixture.setNewsletterRecipientFixture(recipientData);
+        return cy.fixture('customer').then((result) => {
+            return Cypress._.merge(result, recipient);
+        }).then((recipientData) => {
+            return fixture.setNewsletterRecipientFixture(recipientData);
+        });
     });
 });
 
@@ -249,36 +273,38 @@ Cypress.Commands.add('createNewsletterRecipientFixture', (recipient) => {
  * @param {Object} [options={}] - Options concerning creation
  */
 Cypress.Commands.add('createSnippetFixture', () => {
-    let json = {};
-    const fixture = new Fixture();
+    return cy.authenticate().then((authInformation) => {
+        let json = {};
+        const fixture = new Fixture(authInformation);
 
-    const findLanguageId = () => fixture.search('language', {
-        type: 'equals',
-        value: 'English'
-    });
-    const findSetId = () => fixture.search('snippet-set', {
-        type: 'equals',
-        value: 'BASE en-GB'
-    });
-
-    return cy.fixture('snippet')
-        .then((result) => {
-            json = result;
-
-            return Promise.all([
-                findLanguageId(),
-                findSetId()
-            ])
-        })
-        .then(([language, set]) => {
-            return Cypress._.merge(json, {
-                languageId: language.id,
-                setId: set.id
-            });
-        })
-        .then((result) => {
-            return fixture.create('snippet', result);
+        const findLanguageId = () => fixture.search('language', {
+            type: 'equals',
+            value: 'English'
         });
+        const findSetId = () => fixture.search('snippet-set', {
+            type: 'equals',
+            value: 'BASE en-GB'
+        });
+
+        return cy.fixture('snippet')
+            .then((result) => {
+                json = result;
+
+                return Promise.all([
+                    findLanguageId(),
+                    findSetId()
+                ])
+            })
+            .then(([language, set]) => {
+                return Cypress._.merge(json, {
+                    languageId: language.id,
+                    setId: set.id
+                });
+            })
+            .then((result) => {
+                return fixture.create('snippet', result);
+            });
+    });
 });
 
 /**
@@ -290,9 +316,11 @@ Cypress.Commands.add('createSnippetFixture', () => {
  * @param {Object} customer - Options concerning customer
  */
 Cypress.Commands.add('createOrder', (productId, customer) => {
-    const fixture = new OrderFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new OrderFixture(authInformation);
 
-    return fixture.createOrder(productId, customer);
+        return fixture.createOrder(productId, customer);
+    });
 });
 
 /**
@@ -304,12 +332,14 @@ Cypress.Commands.add('createOrder', (productId, customer) => {
  * @param {Object} [userData={}] - Options concerning creation
  */
 Cypress.Commands.add('createGuestOrder', (productId, userData) => {
-    const fixture = new OrderFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new OrderFixture(authInformation);
 
-    return cy.fixture('storefront-customer').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.createGuestOrder(productId, data);
+        return cy.fixture('storefront-customer').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.createGuestOrder(productId, data);
+        });
     });
 });
 
@@ -321,12 +351,14 @@ Cypress.Commands.add('createGuestOrder', (productId, userData) => {
  * @param {Object} userData - Data proved for this order to be created
  */
 Cypress.Commands.add('createAdminOrder', (userData) => {
-    const fixture = new OrderAdminFixture();
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new OrderAdminFixture(authInformation);
 
-    return cy.fixture('order').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setOrderFixture(data);
+        return cy.fixture('order').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setOrderFixture(data);
+        });
     });
 });
 
@@ -338,18 +370,20 @@ Cypress.Commands.add('createAdminOrder', (userData) => {
  * @param {Object} [userData={}] - Options concerning creation
  */
 Cypress.Commands.add('createPromotionFixture', (userData = {}) => {
-    const fixture = new OrderFixture();
-    let promotionId = '';
+    return cy.authenticate().then((authInformation) => {
+        const fixture = new OrderFixture(authInformation);
+        let promotionId = '';
 
-    return cy.fixture('promotion').then((result) => {
-        return Cypress._.merge(result, userData);
-    }).then((data) => {
-        return fixture.setPromotionFixture(data);
-    }).then((data) => {
-        promotionId = data.id;
-        return cy.fixture('discount');
-    }).then((result) => {
-        return fixture.setDiscountFixture(result, promotionId);
+        return cy.fixture('promotion').then((result) => {
+            return Cypress._.merge(result, userData);
+        }).then((data) => {
+            return fixture.setPromotionFixture(data);
+        }).then((data) => {
+            promotionId = data.id;
+            return cy.fixture('discount');
+        }).then((result) => {
+            return fixture.setDiscountFixture(result, promotionId);
+        });
     });
 });
 

--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -8,14 +8,7 @@ const fs = require('fs');
  * @function
  */
 Cypress.Commands.add('activateShopwareTheme', () => {
-    const isStyleLoaded = $head => $head.find('#cypress-dark').length > 0;
-    const themeFilename = 'node_modules/@shopware/e2e-testsuite/theme/shopware.css';
-
-    // Cypress includes jQuery
     const $head = Cypress.$(parent.window.document.head); // eslint-disable-line no-restricted-globals
-    if (isStyleLoaded($head) || !Cypress.config('useShopwareTheme')) {
-        return;
-    }
 
     $head.append(
         `<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.8.2/css/brands.css" integrity="sha384-i2PyM6FMpVnxjRPi0KW/xIS7hkeSznkllv+Hx/MtYDaHA5VcF0yL3KVlvzp8bWjQ" crossorigin="anonymous">

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -19,12 +19,6 @@ require('./commands/storefront-api-commands');
 // Import fixture commands.js
 require('./commands/system-commands');
 
-// Import themes:
-if (Cypress.config('useDarkTheme')) {
-    require('cypress-dark');
-    require('cypress-dark/src/halloween');
-}
-
 Cypress.on('uncaught:exception', (err, runnable) => {
     // returning false here prevents Cypress from
     // failing the test

--- a/cypress/support/service/administration/admin-api.service.js
+++ b/cypress/support/service/administration/admin-api.service.js
@@ -15,6 +15,10 @@ module.exports = class AdminApiService extends ApiService {
      * @returns {Object}
      */
     loginByUserName(username = 'admin', password = 'shopware') {
+        if (this.authInformation && this.authInformation.access_token) {
+            return Promise.resolve(this.authInformation);
+        }
+
         return this.client.post('/oauth/token', {
             grant_type: 'password',
             client_id: 'administration',

--- a/cypress/support/service/administration/fixture.service.js
+++ b/cypress/support/service/administration/fixture.service.js
@@ -2,8 +2,8 @@ const _ = require('lodash');
 const uuid = require('uuid/v4');
 const AdminApiService = require('./admin-api.service');
 class AdminFixtureService {
-    constructor() {
-        this.apiClient = new AdminApiService();
+    constructor(authInformation) {
+        this.apiClient = new AdminApiService(authInformation);
     }
 
     create(endpoint, rawData) {

--- a/cypress/support/service/administration/fixture/property.fixture.js
+++ b/cypress/support/service/administration/fixture/property.fixture.js
@@ -1,8 +1,8 @@
 const AdminFixtureService = require('../fixture.service.js');
 
 class PropertyFixtureService extends AdminFixtureService {
-    constructor() {
-        super();
+    constructor(authInformation) {
+        super(authInformation);
 
         this.propertyFixture = this.loadJson('property-group.json');
     }

--- a/cypress/support/service/administration/fixture/snippet.fixture.js
+++ b/cypress/support/service/administration/fixture/snippet.fixture.js
@@ -1,8 +1,8 @@
 const AdminFixtureService = require('../fixture.service.js');
 
 class SnippetFixtureService extends AdminFixtureService {
-    constructor() {
-        super();
+    constructor(authInformation) {
+        super(authInformation);
         this.snippetFixture = this.loadJson('snippet.json');
     }
 

--- a/cypress/support/service/api.service.js
+++ b/cypress/support/service/api.service.js
@@ -1,8 +1,8 @@
 const axios = require('axios');
 
 module.exports = class ApiService {
-    constructor() {
-        this.authInformation = {};
+    constructor(authInformation) {
+        this.authInformation = authInformation || {};
         this.basePath = '';
 
         this.client = axios.create({

--- a/cypress/support/service/saleschannel/fixture.service.js
+++ b/cypress/support/service/saleschannel/fixture.service.js
@@ -5,9 +5,9 @@ const AdminApiService = require('../administration/admin-api.service');
 const AdminFixtureService = require('../administration/fixture.service.js');
 
 class SalesChannelFixtureService {
-    constructor() {
+    constructor(adminApiAuthInformation) {
         this.apiClient = new StoreApiService(process.env.APP_URL);
-        this.adminApiClient = new AdminApiService(process.env.APP_URL);
+        this.adminApiClient = new AdminApiService(adminApiAuthInformation);
     }
 
     createUuid() {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uuid": "8.3.2"
   },
   "peerDependencies": {
-    "cypress": "7.6.0"
+    "cypress": "5.6.0"
   },
   "engines": {
     "node": ">= 8.10.0",


### PR DESCRIPTION
## Description

Our e2e tests take really long to execute. After analyzing all requests that are triggered by the cypress tests I've noticed that the most time consuming requests (sum of total request time) are `/api/oauth/token` with a total time of around 10-20%. That peaked my interest and I've discovered that for each request another request to get a new authentication token is triggered. This is obviously pretty wasteful.


## Solution

Ideally, the access token should be reused as long as it's not expired. This is accomplished by storing the authentication information inside the new cookie `_apiAuth`. This cookie has to be persisted for this to take affect.

```js
Cypress.Cookies.defaults({
    preserve: ['_apiAuth']
})
```
Otherwise the cookie is cleared after each test. (This change needs to be implemented in shopware/platform admin and storefront).

This caching should be used by all the code that creates fixtures and should not affect the testing of the login.

There are two ways to create fixture data.

1. Use the fixture services which use axios with native javascript promises 
2. Use the generic helper commands which use the normal cypress commands

Sadly, it's not possible to call commands inside the js promise chain, so we cannot access the cookie inside the services. Due to that we have to pass this information into the service on creation time. So a call to `cy.authenticate` should precede the call of any fixture service so that the authentication cache is used.

## Testing

We should test admin and storefront with the current shopware/platform trunk before merging



