### PR TITLE
NEXT-17141 - Empty Search Results through user configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,13 @@ cy.get('.sw-cms-sidebar__block-preview')
   .dragTo('.sw-cms-section__empty-stage');
 ```
 
+#### Set the entity and default search configurations of its fields to be searchable
+
+```js
+cy.setEntitySearchable('shipping_method', 'name');
+cy.setEntitySearchable('media', ['fileName', 'title']);
+```
+
 ### Skip test if a feature is not activated
 
 ```js

--- a/cypress/support/commands/commands.js
+++ b/cypress/support/commands/commands.js
@@ -1046,3 +1046,35 @@ Cypress.Commands.add('handleModalSnapshot', (title) => {
             cy.get('.sw-modal').should('have.css', 'opacity', '1');
         });
 });
+
+
+/**
+ * Set entity and it own specific search configuration fields to be searchable
+ * @memberOf Cypress.Chainable#
+ * @name setEntitySearchable
+ * @param {String} entity - Name of the entity, should be matched with the one defined at each module
+ * @param {String|Array} fields - Array of the fields that you want to be searchable
+ * @function
+ */
+Cypress.Commands.add('setEntitySearchable', (entity, fields = {}) => {
+    cy.window().then(($w) => {
+        const searchConfigurations = $w.Shopware.Module.getModuleByEntityName(entity).manifest.defaultSearchConfiguration;
+        if (typeof searchConfigurations !== 'object') {
+            return;
+        }
+        searchConfigurations._searchable = true;
+        if (typeof fields === 'string') {
+            searchConfigurations[fields]._searchable = true;
+            return;
+        }
+
+        fields.forEach(field => {
+            let currentField = searchConfigurations;
+            field.split('.').forEach(nestedField => currentField = currentField[nestedField]);
+            if (typeof currentField !== 'object') {
+                return;
+            }
+            currentField._searchable = true;
+        });
+    });
+});


### PR DESCRIPTION
# Description

Currently, the default search configurations are already applied for each module for Admin Search Improvement. Therefore, some entity is searchable and some are not (it is happening for the entity's fields as well) by default, it leads to some old e2e case was failures because the search result showed nothing.

# Solution

I decided to write the new command `setEntitySearchable`, it should overwrite the current search configurations to be searchable based on the `entity name` and `the entity's fields` you expect to be searchable. And it would make the remaining old test work normally like before.

The test on `shopware/platform` was successful, I'm pretty sure this change fixes the issue.

