### PR TITLE
NTR - Fix setToInitialState command

### DIFF
--- a/cypress/support/commands/fixture-commands.js
+++ b/cypress/support/commands/fixture-commands.js
@@ -396,7 +396,9 @@ Cypress.Commands.add('createPromotionFixture', (userData = {}) => {
  */
 Cypress.Commands.add('setToInitialState', () => {
     return cy.log('Cleaning, please wait a little bit.').then(() => {
-        return cy.cleanUpPreviousState();
+        return cy.cleanUpPreviousState(() => {
+            return Promise.resolve();
+        });
     }).then(() => {
         return cy.clearCacheAdminApi('DELETE', 'api/_action/cache');
     }).then(() => {


### PR DESCRIPTION
cy.cleanUpPreviousState requires a callback function to be passed.