### PR TITLE
NEXT-17750 - Fix local rollback

### DIFF
--- a/cypress/support/commands/fixture-commands.js
+++ b/cypress/support/commands/fixture-commands.js
@@ -396,9 +396,7 @@ Cypress.Commands.add('createPromotionFixture', (userData = {}) => {
  */
 Cypress.Commands.add('setToInitialState', () => {
     return cy.log('Cleaning, please wait a little bit.').then(() => {
-        return cy.cleanUpPreviousState(() => {
-            return Promise.resolve();
-        });
+        return cy.cleanUpPreviousState();
     }).then(() => {
         return cy.clearCacheAdminApi('DELETE', 'api/_action/cache');
     }).then(() => {

--- a/cypress/support/commands/system-commands.js
+++ b/cypress/support/commands/system-commands.js
@@ -23,31 +23,16 @@ Cypress.Commands.add('activateShopwareTheme', () => {
  * @name cleanUpPreviousState
  * @function
  */
-Cypress.Commands.add('legacyCleanUpPreviousState', () => {
+Cypress.Commands.add('cleanUpPreviousState', () => {
     if (Cypress.env('localUsage')) {
-        return cy.exec(`${Cypress.env('projectRoot')}/psh.phar e2e:restore-db`)
-            .its('stdout').should('contain', 'All commands successfully executed!');
+        return cy.exec(`${Cypress.env('shopwareRoot')}/bin/console e2e:restore-db`)
+            .its('code').should('eq', 0);
     }
 
     return cy.request(`http://${new URL(Cypress.config('baseUrl')).hostname}:8005/cleanup`)
         // ToDo: Remove when cypress issue #5150 is released:
         //  https://github.com/cypress-io/cypress/pull/5150/files
         .its('body').should('eq', 'success');
-});
-
-/**
- * Cleans up any previous state by restoring database and clearing caches
- * @memberOf Cypress.Chainable#
- * @name cleanUpPreviousState
- * @function
- */
-Cypress.Commands.add('cleanUpPreviousState', (orig) => {
-    if (Cypress.env('localUsage')) {
-        return cy.exec(`${Cypress.env('shopwareRoot')}/bin/console e2e:restore-db`)
-            .its('code').should('eq', 0);
-    }
-
-    return orig();
 });
 
 /**


### PR DESCRIPTION
Originally, the `cleanUpPreviousState` function in the core was an override. Therefore, "orig()" made sense. But since it was moved to this repo, "orig()" does not have any effect. Therefore, I merged the functions, to restore the cores functionality in this repo as well