### PR TITLE
NEXT-20166 - Fix cy.login command

### DIFF
--- a/cypress/support/commands/commands.js
+++ b/cypress/support/commands/commands.js
@@ -48,6 +48,9 @@ const { v4: uuid } = require('uuid');
 
         const user = types[userType];
 
+        cy.clearCookie('bearerAuth');
+        cy.clearCookie('refreshBearerAuth');
+
         cy.visit('/admin');
 
         cy.contains(/Username|Benutzername/);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/e2e-testsuite-platform",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "description": "E2E Testsuite for Shopware 6 using Cypress.js",
   "keywords": [
     "e2e",


### PR DESCRIPTION
The command `cy.login` does not work after the first login into the administration. 

We need to clear the cookies before logging in again.