### PR TITLE
NEXT-21187 - fix cypress acl tests in subdomains

### DIFF
--- a/cypress/support/commands/fixture-commands.js
+++ b/cypress/support/commands/fixture-commands.js
@@ -601,6 +601,8 @@ Cypress.Commands.add('loginAsUserWithPermissions', {
         // logout
         cy.get('.sw-admin-menu__user-actions-toggle').click();
         cy.clearCookies();
+        cy.clearCookie('bearerAuth');
+        cy.clearCookie('refreshBearerAuth');
         cy.get('.sw-admin-menu__logout-action').click();
         cy.get('.sw-login__container').should('be.visible');
         cy.reload().then(() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/e2e-testsuite-platform",
-  "version": "3.0.12",
+  "version": "3.0.13",
   "description": "E2E Testsuite for Shopware 6 using Cypress.js",
   "keywords": [
     "e2e",


### PR DESCRIPTION
The clearCookies command does not clear all cypress cookies and this leads to an broken token in the cookies. This happens only in subdomains aka "http://shopware.subfolder.test"