### PR TITLE
NEXT-20396 - Remove StoreApiProxy usage from storefront scope

### DIFF
--- a/cypress/support/commands/storefront-api-commands.js
+++ b/cypress/support/commands/storefront-api-commands.js
@@ -483,18 +483,6 @@ Cypress.Commands.add('loginByGuestAccountViaApi', (userData) => {
     }).then((result) => {
         return Cypress._.merge(result, finalAddressRawData);
     }).then((result) => {
-        cy.getSalesChannelId().then((salesChannelAccessKey) => {
-            const requestConfig = {
-                headers: {
-                    'SW-Access-Key': salesChannelAccessKey,
-                    'cookie': 'csrf[frontend.store-api.proxy]=1b4dfebfc2584cf58b63c72c20d521d0frontend.store-api.proxy#'
-                },
-                body: result,
-                method: 'POST',
-                url: `_proxy/store-api?path=store-api/account/register&response=true`
-            };
-
-            cy.request(requestConfig);
-        });
+        cy.storefrontApiRequest('POST', '/account/register&response=true', {}, result);
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/e2e-testsuite-platform",
-  "version": "3.0.13",
+  "version": "3.0.14",
   "description": "E2E Testsuite for Shopware 6 using Cypress.js",
   "keywords": [
     "e2e",


### PR DESCRIPTION
We want to deprecate and then remove the StoreApiProxy from the Storefront proxy as it makes regularly problems and is just a shortcut to creating own custom controllers.

So we remove the proxy usage here and use the store-api directly