### PR TITLE
NEXT-17944 - Unify the way to manipulate the context token variable

### DIFF
--- a/cypress/support/service/fixture/product-wishlist.fixture.js
+++ b/cypress/support/service/fixture/product-wishlist.fixture.js
@@ -13,7 +13,7 @@ class productWishlistFixture extends StoreFixtureService{
                 }));
             })
             .then((response) => {
-                return this.apiClient.setContextToken(response.data.contextToken);
+                return this.apiClient.setContextToken(response.headers['sw-context-token']);
             })
             .then(() => {
                 return this.apiClient.post(`/customer/wishlist/add/${productId}`);

--- a/cypress/support/service/saleschannel/fixture/order.fixture.js
+++ b/cypress/support/service/saleschannel/fixture/order.fixture.js
@@ -13,7 +13,7 @@ class OrderFixtureService extends SalesChannelFixtureService {
                 }));
             })
             .then((response) => {
-                return this.apiClient.setContextToken(response.data.contextToken);
+                return this.apiClient.setContextToken(response.headers['sw-context-token']);
             })
             .then(() => {
                 return this.apiClient.post('/checkout/cart/line-item', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/e2e-testsuite-platform",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "E2E Testsuite for Shopware 6 using Cypress.js",
   "keywords": [
     "e2e",


### PR DESCRIPTION
Currently, some API endpoints return a ContextTokenResponse and some passes the new token using a response header
We should make unify it to the response header, as the response body is mostly encoded entities or other structs