### PR TITLE
Fix expiry value

### DIFF
--- a/cypress/support/CHANGELOG.md
+++ b/cypress/support/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [7.0.3] - 01.02.2023
+
+### Added
+- Added correct expiry value with same calculation as in the administration
+
 ## [7.0.0] - 10.01.2023
 
 ### Changed

--- a/cypress/support/commands/api-commands.js
+++ b/cypress/support/commands/api-commands.js
@@ -24,6 +24,7 @@ Cypress.Commands.add('authenticate', () => {
                 let result = responseData.body;
                 result.access = result.access_token;
                 result.refresh = result.refresh_token;
+                result.expiry = Math.round(+new Date() / 1000) + result.expires_in;
 
                 cy.log('request /api/oauth/token')
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/e2e-testsuite-platform",
-  "version": "7.0.2",
+  "version": "7.0.3",
   "description": "E2E Testsuite for Shopware 6 using Cypress.js",
   "keywords": [
     "e2e",


### PR DESCRIPTION
The expiry was not set correctly because the administration mutates it to an absolute time value