### PR TITLE
Fix create default sales channel command

### DIFF
--- a/cypress/support/commands/commands.js
+++ b/cypress/support/commands/commands.js
@@ -1128,7 +1128,7 @@ Cypress.Commands.add('createDefaultSalesChannel', (data = {}) => {
             return cy.searchViaAdminApi({
                 endpoint: 'country',
                 data: {
-                    field: 'name',
+                    field: 'iso3',
                     value: 'USA',
                 },
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopware-ag/e2e-testsuite-platform",
-  "version": "7.0.4",
+  "version": "7.0.5",
   "description": "E2E Testsuite for Shopware 6 using Cypress.js",
   "keywords": [
     "e2e",


### PR DESCRIPTION
The `createDefaultSalesChannel` command was failing, because it searched for the use by the name: `USA` this has name has recently however changed to be `United States of America`. This PR changes the condition to search for the ISO3 code `USA`, which should stay the same.